### PR TITLE
Update ADOPTERS.md with Engineering details

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -55,3 +55,11 @@ If you'd like to be included here, please update [this issue](https://github.com
 - Use Case: SparkFabrik leverages Projectsveltos to automate infrastructure deployments across AWS (EKS), Google Kubernetes Engine (GKE), Azure (AKS) and on-premises environments, centrally managing the installation and upgrading of Kubernetes add-ons and applications.
 - Project name: Platform Team
 - Project website: https://www.sparkfabrik.com/
+
+### Engineering
+
+- Website: https://www.eng.it/it
+- Use Case: We use ProjectSveltos with Crossplane to provide on demand Kubernetes clusters to our developers and distribute addons at scale to the managed clusters. It eneabled us to flexibly leverage templates, events and addons deployment ordering with a pretty linear learning curve.
+- Project name: Platform Team
+- Project website: 
+


### PR DESCRIPTION
This pull request adds a new adopter entry for the Engineering team to the `ADOPTERS.md` file. The update includes details about their use case, website, and project information. 

New adopter entry:

* Added "Engineering" as an adopter, including their website, use case involving ProjectSveltos and Crossplane for Kubernetes cluster management, and project details.